### PR TITLE
fix: 搜索组件未拼接 basePath 导致静态站搜索 404

### DIFF
--- a/docs/src/components/search.tsx
+++ b/docs/src/components/search.tsx
@@ -28,6 +28,7 @@ export default function DefaultSearchDialog(props: SharedProps) {
     type: "static",
     initOrama,
     locale,
+    from: `${process.env.NEXT_PUBLIC_BASE_PATH ?? ""}/api/search`,
   });
 
   return (

--- a/docs/src/components/search.tsx
+++ b/docs/src/components/search.tsx
@@ -13,6 +13,7 @@ import {
   type SharedProps,
 } from "fumadocs-ui/components/dialog/search";
 import { useI18n } from "fumadocs-ui/contexts/i18n";
+import { withDocsBasePath } from "@/lib/docs-base-path";
 
 function initOrama() {
   return create({
@@ -28,7 +29,7 @@ export default function DefaultSearchDialog(props: SharedProps) {
     type: "static",
     initOrama,
     locale,
-    from: `${process.env.NEXT_PUBLIC_BASE_PATH ?? ""}/api/search`,
+    from: withDocsBasePath("/api/search"),
   });
 
   return (


### PR DESCRIPTION
## 关联 Issue

Closes #18

## 改动类型

fix

## 改动范围

- `docs/src/components/search.tsx`（1 行新增）

## 改动说明

`useDocsSearch` 未传 `from` 选项，Orama static client 默认从 `/api/search` 拉索引，但 GitHub Pages 部署在 `/ai-native-engineering/` basePath 下，浏览器 `fetch()` 不自动拼接 basePath，导致 404。

修复：传入 `from: \`${process.env.NEXT_PUBLIC_BASE_PATH ?? ""}/api/search\``，利用已在 GitHub Actions 中定义的 `NEXT_PUBLIC_BASE_PATH` 环境变量。开发环境该变量为空串，回退到 `/api/search`，两种环境均正确。

## 验证方式

1. `bun run build` 后检查 `out/api/search` 是否生成
2. 本地 `bun run start` 后打开搜索弹窗输入关键词验证结果

## 规范确认

- [x] Commit 信息使用中文 + Angular 前缀
- [x] 未修改 `docs/` 内容文件