### PR TITLE
fix: Orama 搜索从 English 切换到 Mandarin 中文分词

### DIFF
--- a/docs/bun.lock
+++ b/docs/bun.lock
@@ -8,6 +8,7 @@
         "@fumadocs/base-ui": "^16.7.7",
         "@giscus/react": "^3.1.0",
         "@orama/orama": "^3.1.18",
+        "@orama/tokenizers": "^3.1.18",
         "fumadocs-core": "^16.7.7",
         "fumadocs-mdx": "^14.2.11",
         "fumadocs-ui": "^16.7.7",
@@ -222,6 +223,8 @@
     "@next/swc-win32-x64-msvc": ["@next/swc-win32-x64-msvc@16.2.1", "", { "os": "win32", "cpu": "x64" }, "sha512-qvU+3a39Hay+ieIztkGSbF7+mccbbg1Tk25hc4JDylf8IHjYmY/Zm64Qq1602yPyQqvie+vf5T/uPwNxDNIoeg=="],
 
     "@orama/orama": ["@orama/orama@3.1.18", "", {}, "sha512-a61ljmRVVyG5MC/698C8/FfFDw5a8LOIvyOLW5fztgUXqUpc1jOfQzOitSCbge657OgXXThmY3Tk8fpiDb4UcA=="],
+
+    "@orama/tokenizers": ["@orama/tokenizers@3.1.18", "", { "dependencies": { "@orama/orama": "3.1.18" } }, "sha512-Ra4dFddWZ7hCGPAehnd/6QZjlzQvczYSt1y1Fq4HteJqRu2yvfR6fXvxiUnKi+HIgJYPxKhebJEjvJdF8LYQWg=="],
 
     "@oxfmt/binding-android-arm-eabi": ["@oxfmt/binding-android-arm-eabi@0.41.0", "", { "os": "android", "cpu": "arm" }, "sha512-REfrqeMKGkfMP+m/ScX4f5jJBSmVNYcpoDF8vP8f8eYPDuPGZmzp56NIUsYmx3h7f6NzC6cE3gqh8GDWrJHCKw=="],
 

--- a/docs/package.json
+++ b/docs/package.json
@@ -23,6 +23,7 @@
     "@fumadocs/base-ui": "^16.7.7",
     "@giscus/react": "^3.1.0",
     "@orama/orama": "^3.1.18",
+    "@orama/tokenizers": "^3.1.18",
     "fumadocs-core": "^16.7.7",
     "fumadocs-mdx": "^14.2.11",
     "fumadocs-ui": "^16.7.7",

--- a/docs/src/app/api/search/route.ts
+++ b/docs/src/app/api/search/route.ts
@@ -1,9 +1,9 @@
 import { createFromSource } from "fumadocs-core/search/server";
 import { source } from "@/lib/source";
+import { createTokenizer } from "@orama/tokenizers/mandarin";
 
 export const revalidate = false;
 
 export const { staticGET: GET } = createFromSource(source, {
-  // https://docs.orama.com/docs/orama-js/supported-languages
-  language: "english",
+  tokenizer: createTokenizer(),
 });

--- a/docs/src/components/search.tsx
+++ b/docs/src/components/search.tsx
@@ -1,6 +1,5 @@
 "use client";
 import { create } from "@orama/orama";
-import { createTokenizer } from "@orama/tokenizers/mandarin";
 import { useDocsSearch } from "fumadocs-core/search/client";
 import {
   SearchDialog,
@@ -18,7 +17,6 @@ import { useI18n } from "fumadocs-ui/contexts/i18n";
 function initOrama() {
   return create({
     schema: { _: "string" },
-    tokenizer: createTokenizer(),
   });
 }
 

--- a/docs/src/components/search.tsx
+++ b/docs/src/components/search.tsx
@@ -1,5 +1,6 @@
 "use client";
 import { create } from "@orama/orama";
+import { createTokenizer } from "@orama/tokenizers/mandarin";
 import { useDocsSearch } from "fumadocs-core/search/client";
 import {
   SearchDialog,
@@ -17,8 +18,7 @@ import { useI18n } from "fumadocs-ui/contexts/i18n";
 function initOrama() {
   return create({
     schema: { _: "string" },
-    // https://docs.orama.com/docs/orama-js/supported-languages
-    language: "english",
+    tokenizer: createTokenizer(),
   });
 }
 


### PR DESCRIPTION
## 关联 Issue

Closes #19

## 改动类型

fix

## 改动范围

- `docs/src/app/api/search/route.ts`（服务端索引构建）
- `docs/src/components/search.tsx`（客户端搜索初始化）
- `docs/package.json`（新增 `@orama/tokenizers` 依赖）
- `docs/bun.lock`

## 改动说明

Orama 搜索原来配置 `language: "english"`，英文分词规则（stemming + 英文 SPLITTER 正则）对中文内容完全无效，导致中文搜索质量严重受损。

修复方案：引入 `@orama/tokenizers` 官方中文分词包，使用 `Intl.Segmenter("zh-CN")` 进行中文分词。替换 `language: "english"` 为 `tokenizer: createTokenizer()`，服务端索引构建和客户端搜索初始化同步切换。

### 技术细节

- `@orama/tokenizers@3.1.18` 使用浏览器/Node.js 内置的 `Intl.Segmenter` API（Chrome 87+, Safari 15.4+, Firefox 135+），无额外外部依赖
- 服务端通过 Fumadocs `SharedOptions.tokenizer` 字段传入（类型：`Required<OramaInput>['components']['tokenizer']`）
- 客户端通过 `initOrama` 回调的 `create({ tokenizer })` 传入

## 验证方式

1. `bun run build` 后检查搜索索引生成
2. 本地 `bun run start` 后打开搜索弹窗输入中文关键词（如"控制面"、"护栏"、"Swarm"）
3. 对比修复前后同一中文关键词的搜索结果数量和相关性

## 规范确认

- [x] Commit 信息使用中文 + Angular 前缀
- [x] 未修改 `docs/` 内容文件