### PR TITLE
chore: 新增 PR build check，合入前拦截构建与类型错误

### DIFF
--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -1,0 +1,34 @@
+name: PR Check
+
+on:
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: pr-check-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+
+      - name: Install deps
+        working-directory: docs
+        run: bun install --frozen-lockfile
+
+      - name: Type check
+        working-directory: docs
+        run: bun run types:check
+
+      - name: Build
+        working-directory: docs
+        run: bun run build


### PR DESCRIPTION
## 动机：解决什么问题

PR #26 暴露了一个流程缺口：仓库没有 PR 级别的自动化构建检查。`tokenizer` 的 TypeScript 类型错误（`'tokenizer' does not exist in type 'CreateArguments<...>'`）在 PR 构建阶段就被发现了，但仓库没有自动化机制来拦截这类问题——这次靠人眼 review 发现，下一次未必。

当前的 CI 覆盖情况：

| 流水线 | 触发时机 | 能拦截什么 |
|--------|---------|-----------|
| `deploy-gh-pages.yml` | push to main | 太晚，已经合进去了 |
| `netlify-smoke.yml` | 手动 / webhook | 只测已部署站点的路由可达性 |
| Netlify deploy preview | PR 自动触发 | 验证 Netlify 侧构建，但环境变量与 GitHub Pages 不同，且不是 required check |

缺少的环节：**在 PR 合入前，用与 main 分支一致的环境自动验证「依赖安装 → 类型检查 → 构建成功」这条链路，不依赖人工 review。**

## 改动内容

新增 `.github/workflows/pr-check.yml`，包含 3 个步骤：

1. **Install deps** — `bun install --frozen-lockfile`，验证依赖锁定文件与代码一致
2. **Type check** — `bun run types:check`，拦截 TypeScript 类型错误（正是 #26 那类问题）
3. **Build** — `bun run build`，验证 Next.js 静态导出成功

其他设计决策：
- **concurrency**：同一 PR 只保留最新 run，避免反复 push 产生冗余
- **permissions: contents: read**：只读，与现有 workflow 一致
- **不设 `NEXT_PUBLIC_BASE_PATH`**：PR check 只验证 build 能通过，不需要真实 basePath；未设置时 next.config.mjs 回退到开发模式（`output` 不设为 export 之外的值也能正常构建）

## 边界冻结：明确不改什么

| 不做 | 理由 |
|------|------|
| 不加 `bun run lint` / `bun run format:check` | pre-commit hook 已覆盖格式化；lint 检查可后续单独迭代，本次最小实现 |
| 不加 E2E / Playwright | 开销大（需安装浏览器、启动静态服务器），且已有 `netlify-smoke.yml` 覆盖部署后的冒烟测试 |
| 不加 `workflow_dispatch` | PR check 只服务于 PR，手动触发无意义 |
| 不改 `deploy-gh-pages.yml` 或 `netlify-smoke.yml` | 职责不同，不在本次范围内 |
| 不设 required check（branch protection） | 这是仓库设置层面的操作，不属于代码变更，需要维护者自行在 Settings → Branches 中配置 |

## 验证方式

1. 本 PR 自身就是第一个测试用例——merge 后观察 GitHub Actions 是否正确触发
2. 后续 PR 应出现 `PR Check / check (pull_request)` 状态检查
3. 建议维护者在 Settings → Branches → main → Require status checks to pass → 勾选 `check` 作为 required check

## 规范确认

- [x] Commit 信息使用中文 + Angular 前缀
- [x] 未修改任何已有文件