### PR TITLE
chore: Netlify 构建链路补齐 types:check

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,6 +1,6 @@
 [build]
   base = "docs"
-  command = "bun install --frozen-lockfile && bun run build"
+  command = "bun install --frozen-lockfile && bun run types:check && bun run build"
   publish = "out"
 
 [functions]


### PR DESCRIPTION
## 动机

PR #26 的 `tokenizer` 类型错误（`'tokenizer' does not exist in type 'CreateArguments<...>'`）在 review 阶段被手动发现。Netlify deploy preview 的构建通过了——因为 `next build` 不一定会拦截所有 TS 类型问题，而仓库的 `types:check`（`fumadocs-mdx && next typegen && tsc --noEmit`）是独立的更严格的检查。

当前每个 PR 已经有 Netlify deploy preview 自动跑 `bun install && bun run build`，但缺少类型检查环节。

## 改动内容

改 `netlify.toml` 的 build command，在 `bun run build` 前插入 `bun run types:check`：

```toml
command = "bun install --frozen-lockfile && bun run types:check && bun run build"
```

types:check 失败时 Netlify deploy preview 直接报红，PR 上即可看到，不依赖人工 review。

## 边界冻结

- **不新增** workflow 文件 — 复用 Netlify 已有的 PR 构建链路
- **不改** `deploy-gh-pages.yml` / `netlify-smoke.yml` — 职责不同
- **不改** `docs/package.json` 的 scripts — `types:check` 已存在
- **不设** required check — 仓库设置层面操作，需维护者在 Settings → Branches 中配置

## 验证方式

1. 本 PR 合并后，后续 PR 的 Netlify deploy preview 会在构建阶段先跑 types:check
2. 建议维护者将 Netlify deploy-preview 状态检查设为 required check

## 规范确认

- [x] Commit 信息使用中文 + Angular 前缀
- [x] 只修改了 `netlify.toml` 一行